### PR TITLE
Add functionality to preserve outliner structure

### DIFF
--- a/sketchup_importer/__init__.py
+++ b/sketchup_importer/__init__.py
@@ -20,6 +20,7 @@ along with this program; if not, see http://www.gnu.org/licenses
 
 import math
 import os
+import shutil
 import tempfile
 import time
 
@@ -29,27 +30,36 @@ from bpy.props import (BoolProperty, EnumProperty, FloatProperty, IntProperty,
 from bpy.types import AddonPreferences, Operator
 from bpy_extras.io_utils import (ExportHelper, ImportHelper, unpack_face_list,
                                  unpack_list)
-from mathutils import Matrix, Quaternion, Vector
+from mathutils import Matrix, Euler, Quaternion, Vector
 
 from . import sketchup
 from .SKPutil import *
 
 bl_info = {
     "name": "SketchUp Importer",
-    "author": "Martijn Berger, Sanjay Mehta, Arindam Mondal",
-    "version": (0, 22, 2),
-    "blender": (2, 80, 0),
+    "author": "Martijn Berger, Sanjay Mehta, Arindam Mondal, Peter Kirkham",
+    "version": (0, 23, 1),
+    "blender": (3, 2, 0),
     "description": "Import of native SketchUp (.skp) files",
-    # "warning": "Very early preview",
+    #"warning": "Very early preview",
     "wiki_url": "https://github.com/martijnberger/pyslapi",
-    "tracker_url": "",
+    "doc_url": "https://github.com/arindam-m/pyslapi/wiki",
+    "tracker_url": "https://github.com/arindam-m/pyslapi/wiki/Bug-Report",
     "category": "Import-Export",
     "location": "File > Import"
 }
 
+DEBUG = False
+
+LOGS = True
+
+MIN_LOGS = False
+
+if not LOGS:
+    MIN_LOGS = True
+
 
 class SketchupAddonPreferences(AddonPreferences):
-
     bl_idname = __name__
 
     camera_far_plane: FloatProperty(
@@ -64,47 +74,80 @@ class SketchupAddonPreferences(AddonPreferences):
     )
 
     def draw(self, context):
-
         layout = self.layout
         layout.label(text="- Basic Import Options -")
         row = layout.row()
         row.use_property_split = True
-        row.prop(self, "camera_far_plane")
+        row.prop(self, 'camera_far_plane')
         layout = self.layout
         row = layout.row()
         row.use_property_split = True
-        row.prop(self, "draw_bounds")
+        row.prop(self, 'draw_bounds')
 
 
 def skp_log(*args):
-
+    # Log output by pre-pending "SU |"
     if len(args) > 0:
-        print('SKP | ' + ' '.join(['%s' % a for a in args]))
+        print("SU | " + " ".join(["%s" % a for a in args]))
+
+
+def create_nested_collection(coll_name):
+    context = bpy.context
+    main_coll_name = "SKP Imported Data"  # data imported into this collection
+
+    # Check if the main import collection exists and create it if missing
+    if not bpy.data.collections.get(main_coll_name):
+        skp_main_coll = bpy.data.collections.new(main_coll_name)
+        context.scene.collection.children.link(skp_main_coll)
+
+    # Check if the named collection being created exists and create if missing
+    if not bpy.data.collections.get(coll_name):
+        skp_nested_coll = bpy.data.collections.new(coll_name)
+        bpy.data.collections[main_coll_name].children.link(skp_nested_coll)
+
+    # Set active layer to the named collection just created
+    view_layer_coll = context.view_layer.layer_collection
+    main_parent_coll = view_layer_coll.children[main_coll_name]
+    coll_set_to_active = main_parent_coll.children[coll_name]
+    context.view_layer.active_layer_collection = coll_set_to_active
 
 
 class SceneImporter():
-    def __init__(self):
 
-        self.filepath = '/tmp/untitled.skp'
+    def __init__(self):
+        self.filepath = "/tmp/untitled.skp"
         self.name_mapping = {}
         self.component_meshes = {}
         self.scene = None
         self.layers_skip = []
 
-    def set_filename(self, filename):
-
+    def set_filename(self,
+                     filename):
         self.filepath = filename
         self.basepath, self.skp_filename = os.path.split(self.filepath)
         return self  # allow chaining
 
-    def load(self, context, **options):
-        """load a sketchup file"""
+    #
+    # This is the main method to load a SketchUp file into Blender. The method
+    # is structured to import the following in order:
+    #     1) Import SketchUp scenes and optional last view as cameras.
+    #     2) Import the materials in the SketchUp model.
+    #     3) Import components in the SketchUp model as a group containing
+    #        multiple linked objects if the number of instances for each
+    #        component is higher than a given threshold.
+    #     4) Import remaining mesh objects.
+    #
+    def load(self,
+             context,
+             **options):
+        """Load a SketchUp file"""
 
+        # Blender settings
         self.context = context
         self.reuse_material = options['reuse_material']
         self.reuse_group = options['reuse_existing_groups']
         self.max_instance = options['max_instance']
-        self.render_engine = options['render_engine']
+        #self.render_engine = options['render_engine']
         self.component_stats = defaultdict(list)
         self.component_skip = proxy_dict()
         self.component_depth = proxy_dict()
@@ -113,98 +156,165 @@ class SceneImporter():
         ren_res_y = context.scene.render.resolution_y
         self.aspect_ratio = ren_res_x / ren_res_y
 
-        skp_log(f'Importing: {self.filepath}')
+        # Start stopwatch for overall import
+        _time_main = time.time()
 
+        # Log filename being imported
+        if LOGS:
+            skp_log(f"Importing: {self.filepath}")
         addon_name = __name__.split('.')[0]
         self.prefs = context.preferences.addons[addon_name].preferences
 
-        _time_main = time.time()
-
+        # Open the SketchUp file and access the model using SketchUp API
         try:
             self.skp_model = sketchup.Model.from_file(self.filepath)
         except Exception as e:
-            skp_log(f'Error reading input file: {self.filepath}')
-            skp_log(e)
+            if LOGS:
+                skp_log(f"Error reading input file: {self.filepath}")
+                skp_log(e)
             return {'FINISHED'}
 
+        # Start stopwatch for camera import
+        if not MIN_LOGS:
+            skp_log("")
+            skp_log("=== Importing Sketchup scenes and views as Blender "
+                    "Cameras ===")
+        _time_camera = time.time()
+
+        # Create collection for cameras
+        create_nested_collection("SKP Scenes (as Cameras)")
+
+        # Import a specific named SketchUp scene as a Blender camera and hide
+        # the layers associated with that specific scene
         if options['import_scene']:
+            options['scenes_as_camera'] = False
+            options['import_camera'] = True
             for s in self.skp_model.scenes:
                 if s.name == options['import_scene']:
-                    skp_log(f"Importing Scene '{s.name}'")
+                    if not MIN_LOGS:
+                        skp_log(f"Importing named SketchUp scene '{s.name}'")
                     self.scene = s
+
+                    # Skip s.layers which are the invisible layers
                     self.layers_skip = [l for l in s.layers]
-                    for l in s.layers:
-                        skp_log(f"SKIP: {l.name}")
-            if not self.layers_skip:
-                skp_log('Could not find scene: {}, importing default.'
+            if not self.layers_skip and not MIN_LOGS:
+                skp_log("Scene: '{}' didn't have any invisible layers."
                         .format(options['import_scene']))
+            if self.layers_skip != [] and not MIN_LOGS:
+                hidden_layers = sorted([l.name for l in self.layers_skip])
+                print("SU | Invisible Layer(s)/Tag(s): \n     ", end="")
+                print(*hidden_layers, sep=', ')
 
-        if not self.layers_skip:
-            self.layers_skip = [
-                l for l in self.skp_model.layers if not l.visible
-            ]
-
-        skp_log('Skipping Layers ... ')
-
-        for l in sorted([l.name for l in self.layers_skip]):
-            skp_log(l)
-
-        self.skp_components = proxy_dict(
-            self.skp_model.component_definition_as_dict)
-
-        skp_log(f'Parsed in {(time.time() - _time_main):.4f} sec.')
-
+        # Import each scene as a Blender camera
         if options['scenes_as_camera']:
+            if not MIN_LOGS:
+                skp_log("Importing all SketchUp scenes as Blender cameras")
             for s in self.skp_model.scenes:
                 self.write_camera(s.camera, s.name)
 
+        # Set the active camera and use for 3D view
         if options['import_camera']:
+            if not MIN_LOGS:
+                skp_log("Importing last SketchUp view as Blender camera")
             if self.scene:
                 active_cam = self.write_camera(self.scene.camera,
                                                name=self.scene.name)
-                context.scene.camera = active_cam
+                context.scene.camera = bpy.data.objects[active_cam]
             else:
                 active_cam = self.write_camera(self.skp_model.camera)
-                context.scene.camera = active_cam
-
-        _t1 = time.time()
-        self.write_materials(self.skp_model.materials)
-
-        skp_log(f'Materials imported in {(time.time() - _t1):.4f} sec.')
-
-        _t1 = time.time()
-        D = SKP_util()
+                context.scene.camera = bpy.data.objects[active_cam]
+            for area in bpy.context.screen.areas:
+                if area.type == 'VIEW_3D':
+                    area.spaces[0].region_3d.view_perspective = 'CAMERA'
+                    break
         SKP_util.layers_skip = self.layers_skip
+        if not MIN_LOGS:
+            skp_log("Cameras imported in "
+                    f"{(time.time() - _time_camera):.4f} sec.")
 
+        # Start stopwatch for material imports
+        if not MIN_LOGS:
+            skp_log("")
+            skp_log("=== Importing Sketchup materials into Blender ===")
+        _time_material = time.time()
+        self.write_materials(self.skp_model.materials)
+        if not MIN_LOGS:
+            skp_log("Materials imported in "
+                    f"{(time.time() - _time_material):.4f} sec.")
+
+        # Start stopwatch for component import
+        if not MIN_LOGS:
+            skp_log("")
+            skp_log("=== Importing Sketchup components into Blender ===")
+        _time_analyze_depth = time.time()
+
+        # Create collection for components
+        create_nested_collection('SKP Components')
+
+        # Determine the number of components that exist in the SketchUp model
+        self.skp_components = proxy_dict(
+            self.skp_model.component_definition_as_dict)
+        u_comps = [k for k, v in self.skp_components.items()]
+        if not MIN_LOGS:
+            print(f"SU | Contains {len(u_comps)} components: \n     ", end="")
+            print(*u_comps, sep=', ')
+
+        # Analyse component depths
+        D = SKP_util()
         for c in self.skp_model.component_definitions:
             self.component_depth[c.name] = D.component_deps(c.entities)
+            if DEBUG:
+                print(f"     -- ({c.name}) --\n        "
+                      f"Depth: {self.component_depth[c.name]}\n", end="")
+                print("        Instances (Used): "
+                      f"{c.numInstances} ({c.numUsedInstances})")
+        if not MIN_LOGS:
+            skp_log(f"Component depths analyzed in "
+                    f"{(time.time() - _time_analyze_depth):.4f} sec.")
 
-        skp_log(f'Component depths analyzed in {(time.time() - _t1):.4f} sec.')
-
+        # Import the components as duplicated groups then hide components
         self.write_duplicateable_groups()
-
-        if options["dedub_only"]:
+        bpy.data.collections['SKP Components'].hide_viewport = True
+        for vl in context.scene.view_layers:
+            for l in vl.active_layer_collection.children:
+                if l.name == 'SKP Components':
+                    l.exclude = True  # hide component collection in view layer
+        if options['dedub_only']:
             return {'FINISHED'}
 
-        self.component_stats = defaultdict(list)
-        self.write_entities(self.skp_model.entities, "Sketchup",
-                            Matrix.Identity(4))
+        # Start stopwatch for mesh objects import
+        if not MIN_LOGS:
+            skp_log("")
+            skp_log("=== Importing Sketchup mesh objects into Blender ===")
+        _time_mesh_data = time.time()
 
+        # Create collection for mesh objects
+        create_nested_collection('SKP Mesh Objects')
+
+        # Import mesh objects into structure that matches the SketchUp outliner
+        self.write_entities(self.skp_model.entities,
+                            "_(Loose Entity)",
+                            Matrix.Identity(4))
         for k, _v in self.component_stats.items():
             name, mat = k
-            if options['dedub_type'] == "VERTEX":
+            if options['dedub_type'] == 'VERTEX':
                 self.instance_group_dupli_vert(name, mat, self.component_stats)
             else:
                 self.instance_group_dupli_face(name, mat, self.component_stats)
+        if not MIN_LOGS:
+            skp_log("Entities imported in "
+                    f"{(time.time() - _time_mesh_data):.4f} sec.")
 
-        skp_log(f'Entities imported in {(time.time() - _t1):.4f} sec.')
-        skp_log('Finished importing in %.4f sec.\n' %
-                (time.time() - _time_main))
-
+        # Importing has completed
+        if LOGS:
+            skp_log("Finished entire importing process in %.4f sec.\n" %
+                    (time.time() - _time_main))
         return {'FINISHED'}
 
+    #
+    # Write components as groups that can be duplicated later.
+    #
     def write_duplicateable_groups(self):
-
         component_stats = self.analyze_entities(
             self.skp_model.entities,
             "Sketchup",
@@ -212,6 +322,10 @@ class SceneImporter():
             component_stats=defaultdict(list))
         instance_when_over = self.max_instance
         max_depth = max(self.component_depth.values(), default=0)
+
+        # Filter out components from list if the total number of instances
+        # is lower than the minimum threshold for creating duplicated mesh
+        # objects.
         component_stats = {
             k: v
             for k, v in component_stats.items() if len(v) >= instance_when_over
@@ -220,23 +334,21 @@ class SceneImporter():
             for k, v in component_stats.items():
                 name, mat = k
                 depth = self.component_depth[name]
-                #print(k, len(v), depth)
                 comp_def = self.skp_components[name]
                 if comp_def and depth == 1:
-                    #self.component_skip[(name,mat)] = comp_def.entities
+                    #self.component_skip[(name, mat)] = comp_def.entities
                     pass
                 elif comp_def and depth == i:
                     gname = group_name(name, mat)
                     if self.reuse_group and gname in bpy.data.collections:
-                        #print("Group {} already defined".format(gname))
+                        skp_log("Group {} already defined".format(gname))
                         self.component_skip[(name, mat)] = comp_def.entities
-                        # grp_name = bpy.data.collections[gname]
                         self.group_written[(name,
                                             mat)] = bpy.data.collections[gname]
                     else:
                         group = bpy.data.collections.new(name=gname)
-                        #print("Component written as group".format(gname))
-                        self.conponent_def_as_group(comp_def.entities,
+                        skp_log("Component {} written as group".format(gname))
+                        self.component_def_as_group(comp_def.entities,
                                                     name,
                                                     Matrix(),
                                                     default_material=mat,
@@ -252,16 +364,17 @@ class SceneImporter():
                          default_material="Material",
                          etype=EntityType.none,
                          component_stats=None,
-                         component_skip=[]):
-
+                         component_skip=None):
+        if component_skip is None:
+            component_skip = []
         if etype == EntityType.component:
             component_stats[(name, default_material)].append(transform)
-
         for group in entities.groups:
             if self.layers_skip and group.layer in self.layers_skip:
                 continue
-            # print(transform)
-            # print(Matrix(group.transform))
+            if DEBUG:
+                print(f"     |G {group.name}")
+                print(f"     {Matrix(group.transform)}")
             self.analyze_entities(group.entities,
                                   "G-" + group.name,
                                   transform @ Matrix(group.transform),
@@ -269,7 +382,6 @@ class SceneImporter():
                                       group.material, default_material),
                                   etype=EntityType.group,
                                   component_stats=component_stats)
-
         for instance in entities.instances:
             if self.layers_skip and instance.layer in self.layers_skip:
                 continue
@@ -277,20 +389,24 @@ class SceneImporter():
             cdef = self.skp_components[instance.definition.name]
             if (cdef.name, mat) in component_skip:
                 continue
+            if DEBUG:
+                print(f"     |C {cdef.name}")
+                print(f"     {Matrix(instance.transform)}")
             self.analyze_entities(cdef.entities,
                                   cdef.name,
                                   transform @ Matrix(instance.transform),
                                   default_material=mat,
                                   etype=EntityType.component,
                                   component_stats=component_stats)
-
         return component_stats
 
-    def write_materials(self, materials):
-
-        if self.context.scene.render.engine != self.render_engine:
-            self.context.scene.render.engine = self.render_engine
-
+    #
+    # Import materials from SketchUp into Blender.
+    #
+    def write_materials(self,
+                        materials):
+        if self.context.scene.render.engine != 'CYCLES':
+            self.context.scene.render.engine = 'CYCLES'
         self.materials = {}
         self.materials_scales = {}
         if self.reuse_material and 'Material' in bpy.data.materials:
@@ -298,19 +414,15 @@ class SceneImporter():
         else:
             bmat = bpy.data.materials.new('Material')
             bmat.diffuse_color = (.8, .8, .8, 0)
-            if self.render_engine == 'CYCLES':
-                bmat.use_nodes = True
+            #if self.render_engine == 'CYCLES':
+            bmat.use_nodes = True
             self.materials['Material'] = bmat
-
         for mat in materials:
-
             name = mat.name
-
             if mat.texture:
                 self.materials_scales[name] = mat.texture.dimensions[2:]
             else:
                 self.materials_scales[name] = (1.0, 1.0)
-
             if self.reuse_material and not name in bpy.data.materials:
                 bmat = bpy.data.materials.new(name)
                 r, g, b, a = mat.color
@@ -320,31 +432,47 @@ class SceneImporter():
                                       math.pow((b / 255.0), 2.2),
                                       round((a / 255.0), 2))  # sRGB to Linear
 
+                if round((a / 255.0), 2) < 1:
+                    bmat.blend_method = 'BLEND'
+                bmat.use_nodes = True
+                default_shader = bmat.node_tree.nodes['Principled BSDF']
+                default_shader_base_color = default_shader.inputs['Base Color']
+                default_shader_base_color.default_value = bmat.diffuse_color
+                default_shader_alpha = default_shader.inputs['Alpha']
+                default_shader_alpha.default_value = round((a / 255.0), 2)
                 if tex:
                     tex_name = tex.name.split("\\")[-1]
-                    tmp_name = os.path.join(tempfile.gettempdir(), tex_name)
-                    # skp_log(f"Texture saved temporarily at {tmp_name}")
-                    tex.write(tmp_name)
-                    img = bpy.data.images.load(tmp_name)
+                    temp_dir = tempfile.gettempdir()
+                    skp_fname = self.filepath.split("\\")[-1].split(".")[0]
+                    temp_dir += '\\' + skp_fname
+                    if not os.path.isdir(temp_dir):
+                        os.mkdir(temp_dir)
+                    temp_file_path = os.path.join(temp_dir, tex_name)
+                    #skp_log(f"Texture saved temporarily at {temp_file_path}")
+                    tex.write(temp_file_path)
+                    img = bpy.data.images.load(temp_file_path)
                     img.pack()
-                    os.remove(tmp_name)
-
-                    if self.render_engine == 'CYCLES':
-                        bmat.use_nodes = True
-                        n = bmat.node_tree.nodes.new('ShaderNodeTexImage')
-                        n.image = img
-                        bmat.node_tree.links.new(
-                            n.outputs['Color'], bmat.node_tree.
-                            nodes['Principled BSDF'].inputs['Base Color'])
-                    else:
-                        btex = bpy.data.textures.new(tex_name, 'IMAGE')
-                        btex.image = img
-                        slot = bmat.texture_slots.add()
-                        slot.texture = btex
-
+                    #os.remove(temp_file_path)
+                    shutil.rmtree(temp_dir)
+                    #if self.render_engine == 'CYCLES':
+                    #    bmat.use_nodes = True
+                    tex_node = bmat.node_tree.nodes.new('ShaderNodeTexImage')
+                    tex_node.image = img
+                    tex_node.location = Vector((-750, 225))
+                    bmat.node_tree.links.new(
+                        tex_node.outputs['Color'], default_shader_base_color)
+                    bmat.node_tree.links.new(
+                        tex_node.outputs['Alpha'], default_shader_alpha)
+                #else:
+                #    btex = bpy.data.textures.new(tex_name, 'IMAGE')
+                #    btex.image = img
+                #    slot = bmat.texture_slots.add()
+                #    slot.texture = btex
                 self.materials[name] = bmat
             else:
                 self.materials[name] = bpy.data.materials[name]
+            if not MIN_LOGS:
+                print(f"     {name}")
 
     def write_mesh_data(self,
                         entities=None,
@@ -365,6 +493,7 @@ class SceneImporter():
         uvs_used = False
 
         for f in entities.faces:
+
             if f.material:
                 mat_number = mats[f.material.name]
             else:
@@ -374,7 +503,7 @@ class SceneImporter():
                         f.st_scale = self.materials_scales[default_material]
                     except KeyError as _e:
                         pass
-            
+
             vs, tri, uvs = f.tessfaces
             num_loops = 0
 
@@ -429,18 +558,19 @@ class SceneImporter():
                 try:
                     bmat = self.materials[k]
                 except KeyError as _e:
-                    bmat = self.materials["Material"]
+                    bmat = self.materials['Material']
                 me.materials.append(bmat)
-                # if bmat.alpha < 1.0:
-                #     alpha = True
+                #if bmat.alpha < 1.0:
+                #    alpha = True
                 try:
-                    if self.render_engine == 'CYCLES':
-                        if 'Image Texture' in bmat.node_tree.nodes.keys():
-                            uvs_used = True
-                    else:
-                        for ts in bmat.texture_slots:
-                            if ts is not None and ts.texture_coords is not None:
-                                uvs_used = True
+                    #                    if self.render_engine == 'CYCLES':
+                    if 'Image Texture' in bmat.node_tree.nodes.keys():
+                        uvs_used = True
+                #else:
+                #    for ts in bmat.texture_slots:
+                #        if ts is not None and ts.texture_coords is not
+                #                        None:
+                #            uvs_used = True
                 except AttributeError as _e:
                     uvs_used = False
         else:
@@ -458,16 +588,16 @@ class SceneImporter():
         loop_total = list(map(lambda f: len(f), tri_faces))
 
         me.vertices.add(len(verts))
-        me.vertices.foreach_set("co", unpack_list(verts))
+        me.vertices.foreach_set('co', unpack_list(verts))
 
         me.loops.add(len(loops_vert_idx))
-        me.loops.foreach_set("vertex_index", loops_vert_idx)
+        me.loops.foreach_set('vertex_index', loops_vert_idx)
 
         me.polygons.add(tri_face_count)
-        me.polygons.foreach_set("loop_start", loop_start)
-        me.polygons.foreach_set("loop_total", loop_total)
-        me.polygons.foreach_set("material_index", mat_index)
-        me.polygons.foreach_set("use_smooth", smooth)
+        me.polygons.foreach_set('loop_start', loop_start)
+        me.polygons.foreach_set('loop_total', loop_total)
+        me.polygons.foreach_set('material_index', mat_index)
+        me.polygons.foreach_set('use_smooth', smooth)
 
         if uvs_used:
             k, l = 0, 0
@@ -488,42 +618,101 @@ class SceneImporter():
 
         return me, alpha
 
+    #
+    # Recursively import all the mesh objects. Groups containing no mesh
+    # information are imported as empty objects and can contain nested
+    # groups or components. This approach preserves the hierarchy from the
+    # SketchUp outliner.
+    #
     def write_entities(self,
                        entities,
                        name,
-                       parent_tranform,
-                       default_material="Material",
-                       etype=None):
+                       parent_transform,
+                       default_material='Material',
+                       etype=None,
+                       parent_name=None,
+                       parent_location=Vector((0, 0, 0))):
 
+        # Check if this is a component that has already been duplicated. We
+        # can skip writing this if it is already contained in a duplication
+        # group.
         if etype == EntityType.component and (
                 name, default_material) in self.component_skip:
             self.component_stats[(name,
-                                  default_material)].append(parent_tranform)
+                                  default_material)].append(parent_transform)
             return
 
-        me, alpha = self.write_mesh_data(entities=entities,
-                                         name=name,
+        # Get the mesh data for this object
+        me, alpha = self.write_mesh_data(entities=entities, name=name,
                                          default_material=default_material)
 
-        if me:
+        # If there are no further nested groups or components, then we can
+        # create an object containing the mesh. Otherwise we create a new
+        # empty object and place an object containing the loose geometry as
+        # a mesh within this group.
+        nested_groups = 0
+        for group in entities.groups:
+            nested_groups += 1  # count groups (brute force approach)
+        nested_comps = 0
+        for comp in entities.instances:
+            nested_comps += 1  # count components (brute force approach)
+        nested_count = nested_groups + nested_comps
+        hide_empty = False
+        if nested_count == 0 or name == "_(Loose Entity)":
             ob = bpy.data.objects.new(name, me)
-            ob.matrix_world = parent_tranform
-            if alpha > 0.01 and alpha < 1.0:
+            ob.matrix_world = parent_transform
+            if 0.01 < alpha < 1.0:
                 ob.show_transparent = True
-            me.update(calc_edges=True)
-            bpy.context.collection.objects.link(ob)
+            if me:
+                me.update(calc_edges=True)
+        else:
+            ob = bpy.data.objects.new(name, None)  # empty object to hold group
+            ob.matrix_world = parent_transform
+            #ob.hide_viewport = True  # disable empties in viewport
+            hide_empty = True
+            if me:
+                ob_mesh = bpy.data.objects.new("_" + name + " (Loose Mesh)",
+                                               me)
+                ob_mesh.matrix_world = parent_transform
+                if 0.01 < alpha < 1.0:
+                    ob_mesh.show_transparent = True
+                me.update(calc_edges=True)
+                ob_mesh.parent = ob
+                ob_mesh.location = Vector((0, 0, 0))
+                bpy.context.collection.objects.link(ob_mesh)
+
+        # Nested adjustments to the world matrix
+        loc = ob.location
+        nested_location = Vector((loc[0], loc[1], loc[2]))
+
+        # Nest the object by assigning it to the parent object
+        if parent_name is not None and parent_name != "_(Loose Entity)":
+            ob.parent = bpy.data.objects[parent_name]
+            ob.location -= parent_location
+        if nested_count > 0:
+            ob.rotation_mode = 'QUATERNION'  # change from default mode of xyz
+            ob.rotation_quaternion = Vector((1, 0, 0, 0))
+            ob.scale = Vector((1, 1, 1))
+        bpy.context.collection.objects.link(ob)
+        ob.hide_set(hide_empty)  # enable but do not show empties in viewport
 
         for group in entities.groups:
             if group.hidden:
                 continue
             if self.layers_skip and group.layer in self.layers_skip:
                 continue
+            temp_ob = bpy.data.objects.new(group.name, None)
+            gname = "G-" + group_safe_name(temp_ob.name)
+            if DEBUG:
+                print(f"     Grp: {gname} in {ob.name}")
             self.write_entities(group.entities,
-                                "G-" + group_safe_name(group.name),
-                                parent_tranform @ Matrix(group.transform),
+                                gname,
+                                parent_transform @ Matrix(group.transform),
                                 default_material=inherent_default_mat(
                                     group.material, default_material),
-                                etype=EntityType.group)
+                                etype=EntityType.group,
+                                parent_name=ob.name,
+                                parent_location=nested_location)
 
         for instance in entities.instances:
             if instance.hidden:
@@ -533,20 +722,29 @@ class SceneImporter():
             mat_name = inherent_default_mat(instance.material,
                                             default_material)
             cdef = self.skp_components[instance.definition.name]
+            if instance.name == "":
+                cname = "C-" + cdef.name
+            else:
+                cname = instance.name + " (C-" + cdef.name + ")"
+            if DEBUG:
+                print(f"     Cmp: {cname} in {ob.name}")
             self.write_entities(cdef.entities,
-                                cdef.name,
-                                parent_tranform @ Matrix(instance.transform),
+                                cname,
+                                parent_transform @ Matrix(instance.transform),
                                 default_material=mat_name,
-                                etype=EntityType.component)
+                                etype=EntityType.component,
+                                parent_name=ob.name,
+                                parent_location=nested_location)
 
-    def instance_object_or_group(self, name, default_material):
-
+    def instance_object_or_group(self,
+                                 name,
+                                 default_material):
         try:
             group = self.group_written[(name, default_material)]
             ob = bpy.data.objects.new(name=name, object_data=None)
-            # ob.dupli_type = 'GROUP'
-            # ob.dupli_group = group
-            # ob.empty_draw_size = 0.01
+            ob.instance_type = 'COLLECTION'
+            ob.instance_collection = group
+            ob.empty_display_size = 0.01
             return ob
         except KeyError as _e:
             me, alpha = self.component_meshes[(name, default_material)]
@@ -556,11 +754,11 @@ class SceneImporter():
             me.update(calc_edges=True)
             return ob
 
-    def conponent_def_as_group(self,
+    def component_def_as_group(self,
                                entities,
                                name,
-                               parent_tranform,
-                               default_material="Material",
+                               parent_transform,
+                               default_material='Material',
                                etype=None,
                                group=None):
 
@@ -568,116 +766,109 @@ class SceneImporter():
             if (name, default_material) in self.component_skip:
                 return
             else:
-                skp_log("Write instance definition as group {} {}".format(
-                    group.name, default_material))
+                if DEBUG:
+                    skp_log("Write instance definition as group {} {}".format(
+                        group.name, default_material))
                 self.component_skip[(name, default_material)] = True
-
         if etype == EntityType.component and (
                 name, default_material) in self.component_skip:
             ob = self.instance_object_or_group(name, default_material)
-            ob.matrix_world = parent_tranform
-            # self.context.scene.objects.link(ob)
+            ob.matrix_world = parent_transform
             self.context.collection.objects.link(ob)
-            # ob.layers = 18 * [False] + [True] + [False]
+            try:
+                ob.layers = 18 * [False] + [True] + [False]
+            except:
+                pass  # capture AttributeError
             group.objects.link(ob)
-
             return
-
         else:
-            me, alpha = self.write_mesh_data(entities=entities,
-                                             name=name,
+            me, alpha = self.write_mesh_data(entities=entities, name=name,
                                              default_material=default_material)
-
         if me:
             ob = bpy.data.objects.new(name, me)
-            ob.matrix_world = parent_tranform
+            ob.matrix_world = parent_transform
             if alpha:
                 ob.show_transparent = True
             me.update(calc_edges=True)
-            # self.context.scene.objects.link(ob)
             self.context.collection.objects.link(ob)
-            # ob.layers = 18 * [False] + [True] + [False]
+            try:
+                ob.layers = 18 * [False] + [True] + [False]
+            except:
+                pass  # capture AttributeError
             group.objects.link(ob)
-
         for g in entities.groups:
             if self.layers_skip and g.layer in self.layers_skip:
                 continue
-            self.conponent_def_as_group(
+            self.component_def_as_group(
                 g.entities,
                 "G-" + g.name,
-                parent_tranform @ Matrix(g.transform),
+                parent_transform @ Matrix(g.transform),
                 default_material=inherent_default_mat(g.material,
                                                       default_material),
                 etype=EntityType.group,
                 group=group)
-
         for instance in entities.instances:
             if self.layers_skip and instance.layer in self.layers_skip:
                 continue
             cdef = self.skp_components[instance.definition.name]
-            self.conponent_def_as_group(
+            self.component_def_as_group(
                 cdef.entities,
                 cdef.name,
-                parent_tranform @ Matrix(instance.transform),
+                parent_transform @ Matrix(instance.transform),
                 default_material=inherent_default_mat(instance.material,
                                                       default_material),
                 etype=EntityType.component,
                 group=group)
 
+    #
+    # Creates a single group in a collection that contains duplicated
+    # instances of a component. Scaling and rotations are used to identify
+    # similar components. Each duplicate group contains components with the
+    # same scale and rotation applied.
+    #
     def instance_group_dupli_vert(self,
                                   name,
                                   default_material,
                                   component_stats):
 
         def get_orientations(v):
-
             orientations = defaultdict(list)
-
             for transform in v:
                 loc, rot, scale = Matrix(transform).decompose()
                 scale = (scale[0], scale[1], scale[2])
                 rot = (rot[0], rot[1], rot[2], rot[3])
                 orientations[(scale, rot)].append((loc[0], loc[1], loc[2]))
-
             for key, locs in orientations.items():
                 scale, rot = key
                 yield scale, rot, locs
 
+        # Create a new group with duplicated components as a linked object.
+        # Each duplicated group has a specific location, scale and rotation
+        # applied.
         for scale, rot, locs in get_orientations(
                 component_stats[(name, default_material)]):
             verts = []
             main_loc = Vector(locs[0])
             for c in locs:
                 verts.append(Vector(c) - main_loc)
-            
-            '''
-            dme = bpy.data.meshes.new('DUPLI_' + name)
+            dme = bpy.data.meshes.new("DUPLI-" + name)
             dme.vertices.add(len(verts))
             dme.vertices.foreach_set("co", unpack_list(verts))
-            dme.update(calc_edges=True)  # Update mesh with new data
+            dme.update(calc_edges=True)  # update mesh with new data
             dme.validate()
-            dob = bpy.data.objects.new("DUPLI_" + name, dme)
+            dob = bpy.data.objects.new("DUPLI-" + name, dme)
             dob.location = main_loc
-            # dob.dupli_type = 'VERTS'
-            '''
-            dme = bpy.data.meshes.new('DUPLI_' + name)
-            dme.from_pydata(verts,[],faces)
-
-            dob = bpy.data.objects.new("DUPLI_" + name, dme)
-            dob.location = main_loc
-
+            dob.instance_type = 'VERTS'
             ob = self.instance_object_or_group(name, default_material)
             ob.scale = scale
-            ob.rotation_quaternion = Quaternion(
-                (rot[0], rot[1], rot[2], rot[3]))
+            ob.rotation_mode = 'QUATERNION'  # change from default mode of xyz
+            ob.rotation_quaternion = Quaternion((rot[0], rot[1], rot[2],
+                                                 rot[3]))
             ob.parent = dob
-
             self.context.collection.objects.link(ob)
             self.context.collection.objects.link(dob)
-            skp_log(
-                "Complex group {} {} instanced {} times, scale -> {}".format(
-                    name, default_material, len(verts), scale))
-
+            skp_log(f"Complex group {name} {default_material} instanced "
+                    f"{len(verts)} times, scale -> {scale}, rot -> {rot}")
         return
 
     def instance_group_dupli_face(self,
@@ -686,63 +877,46 @@ class SceneImporter():
                                   component_stats):
 
         def get_orientations(v):
-
             orientations = defaultdict(list)
-
             for transform in v:
                 _loc, _rot, scale = Matrix(transform).decompose()
                 scale = (scale[0], scale[1], scale[2])
                 orientations[scale].append(transform)
-
             for scale, transforms in orientations.items():
                 yield scale, transforms
 
         for _scale, transforms in get_orientations(
                 component_stats[(name, default_material)]):
-            main_loc, _, real_scale = Matrix(transforms[0]).decompose()
+            main_loc, _real_rot, real_scale = Matrix(transforms[0]).decompose()
             verts = []
             faces = []
             f_count = 0
-
             for c in transforms:
                 l_loc, l_rot, _l_scale = Matrix(c).decompose()
-                mat = Matrix.Translation(l_loc) @ l_rot.to_matrix().to_4x4()
-
+                mat = Matrix.Translation(l_loc) * l_rot.to_matrix().to_4x4()
                 verts.append(Vector(
-                    (mat @ Vector((-0.05, -0.05, 0, 1.0)))[0:3]) - main_loc)
+                    (mat * Vector((-0.05, -0.05, 0, 1.0)))[0:3]) - main_loc)
                 verts.append(Vector(
-                    (mat @ Vector((0.05, -0.05, 0, 1.0)))[0:3]) - main_loc)
+                    (mat * Vector((0.05, -0.05, 0, 1.0)))[0:3]) - main_loc)
                 verts.append(Vector(
-                    (mat @ Vector((0.05, 0.05, 0, 1.0)))[0:3]) - main_loc)
+                    (mat * Vector((0.05, 0.05, 0, 1.0)))[0:3]) - main_loc)
                 verts.append(Vector(
-                    (mat @ Vector((-0.05, 0.05, 0, 1.0)))[0:3]) - main_loc)
-
+                    (mat * Vector((-0.05, 0.05, 0, 1.0)))[0:3]) - main_loc)
                 faces.append(
                     (f_count + 0, f_count + 1, f_count + 2, f_count + 3))
-
                 f_count += 4
-
-            '''
-            dme = bpy.data.meshes.new('DUPLI_' + name)
+            dme = bpy.data.meshes.new("DUPLI-" + name)
             dme.vertices.add(len(verts))
-            dme.vertices.foreach_set("co", unpack_list(verts))
-
-            # dme.loop_triangles.add(f_count / 4)
-            dme.loop_triangles.foreach_set("vertices_raw", unpack_face_list(faces))
+            dme.vertices.foreach_set('co', unpack_list(verts))
+            dme.tessfaces.add(f_count / 4)
+            dme.tessfaces.foreach_set('vertices_raw', unpack_face_list(faces))
             dme.update(calc_edges=True)  # Update mesh with new data
             dme.validate()
-            dob = bpy.data.objects.new("DUPLI_" + name, dme)
-            # dob.dupli_type = 'FACES'
+            dob = bpy.data.objects.new("DUPLI-" + name, dme)
+            dob.instance_type = 'FACES'
             dob.location = main_loc
             #dob.use_dupli_faces_scale = True
             #dob.dupli_faces_scale = 10
-            '''
-            dme = bpy.data.meshes.new('DUPLI_' + name)
-            dme.from_pydata(verts,[],faces)
-
-            dob = bpy.data.objects.new("DUPLI_" + name, dme)
-            dob.location = main_loc
-
             ob = self.instance_object_or_group(name, default_material)
             ob.scale = real_scale
             ob.parent = dob
@@ -750,75 +924,73 @@ class SceneImporter():
             self.context.collection.objects.link(dob)
             skp_log("Complex group {} {} instanced {} times".format(
                 name, default_material, f_count / 4))
-
         return
 
-    def write_camera(self, camera, name="Active Camera"):
-
+    def write_camera(self,
+                     camera,
+                     name="Last View"):
+        skp_log(f"Writing camera: {name}")
         pos, target, up = camera.GetOrientation()
         bpy.ops.object.add(type='CAMERA', location=pos)
         ob = self.context.object
-        ob.name = name
-
+        ob.name = "Cam: " + name
         z = (Vector(pos) - Vector(target))
         x = Vector(up).cross(z)
         y = z.cross(x)
-
         x.normalize()
         y.normalize()
         z.normalize()
-
         ob.matrix_world.col[0] = x.resized(4)
         ob.matrix_world.col[1] = y.resized(4)
         ob.matrix_world.col[2] = z.resized(4)
-
         cam = ob.data
         aspect_ratio = camera.aspect_ratio
         fov = camera.fov
         if aspect_ratio == False:
-            # skp_log(f"Camera:'{name}' uses dynamic/screen aspect ratio.")
+            skp_log(f"Cam: '{name}' uses dynamic/screen aspect ratio.")
             aspect_ratio = self.aspect_ratio
         if fov == False:
-            skp_log(f"Camera:'{name}'' is in Orthographic Mode.")
+            skp_log(f"Cam: '{name}' is in Orthographic Mode.")
             cam.type = 'ORTHO'
+        #cam.ortho_scale = 3.0
         else:
             cam.angle = (math.pi * fov / 180) * aspect_ratio
         cam.clip_end = self.prefs.camera_far_plane
-        cam.name = name
+        cam.name = "Cam: " + name
+        return cam.name
 
 
 class SceneExporter():
 
     def __init__(self):
-
         self.filepath = '/tmp/untitled.skp'
 
     def set_filename(self, filename):
-
         self.filepath = filename
         self.basepath, self.skp_filename = os.path.split(self.filepath)
-
         return self
 
     def save(self, context, **options):
-
-        skp_log(f'Finished exporting: {self.filepath}')
-
+        skp_log(f"Finished exporting: {self.filepath}")
         return {'FINISHED'}
 
 
 class ImportSKP(Operator, ImportHelper):
-    """Load a Trimble Sketchup SKP file"""
-
-    bl_idname = "import_scene.skp"
+    """Load a Trimble SketchUp .skp file"""
+    bl_idname = 'import_scene.skp'
     bl_label = "Import SKP"
-    bl_options = {'PRESET', 'UNDO'}
-
-    filename_ext = ".skp"
+    bl_options = {'PRESET', 'REGISTER', 'UNDO'}
+    filename_ext = '.skp'
 
     filter_glob: StringProperty(
         default="*.skp",
         options={'HIDDEN'},
+    )
+
+    scenes_as_camera: BoolProperty(
+        name="Scene(s) As Camera(s)",
+        description="Import SketchUp Scenes As Blender Camera.",
+        default=True
     )
 
     import_camera: BoolProperty(
@@ -833,63 +1005,57 @@ class ImportSKP(Operator, ImportHelper):
         default=True
     )
 
+    dedub_only: BoolProperty(
+        name="Groups Only",
+        description="Import instantiated groups only.",
+        default=False
+    )
+
+    reuse_existing_groups: BoolProperty(
+        name="Reuse Groups",
+        description="Use existing Blender groups to instance components with.",
+        default=False
+    )
+
+    # Altered from initial default of 50 so as to force import all
+    # components to be imported as duplicated objects.
     max_instance: IntProperty(
-        name="Threshold :",
-        default=50
+        name="Instantiation Threshold :",
+        default=1
     )
 
     dedub_type: EnumProperty(
         name="Instancing Type :",
         items=(('FACE', "Faces", ""),
-               ('VERTEX', "Verts", ""),),
-        default='FACE',
-    )
-
-    dedub_only: BoolProperty(
-        name="Groups Only",
-        description="Import instanciated groups only.",
-        default=False
-    )
-
-    scenes_as_camera: BoolProperty(
-        name="Scene(s) As Camera(s)",
-        description="Import SketchUp Scenes As Blender Camera.",
-        default=True
+               ('VERTEX', "Vertices", ""),),
+        default='VERTEX',
     )
 
     import_scene: StringProperty(
         name="Import A Scene :",
-        description="Import a specific Sketchup Scene",
+        description="Import a specific SketchUp Scene",
         default=""
     )
 
-    reuse_existing_groups: BoolProperty(
-        name="Reuse Groups",
-        description="Use existing Blender groups to instance componenets with.",
-        default=False
-    )
+    #render_engine: EnumProperty(
+    #    name="Default Shaders In :",
+    #    items=(('CYCLES', "Cycles", ""),
+    #           #    ('BLENDER_RENDER', "Blender Render", "")
+    #           ),
+    #    default='CYCLES'
+    #)
 
-    render_engine: EnumProperty(
-        name="Default Shaders In :",
-        items=(('CYCLES', "Cycles", ""),
-               #    ('BLENDER_RENDER', "Blender Render", "")
-               ),
-        default='CYCLES'
-    )
-
-    def execute(self, context):
-
+    def execute(self,
+                context):
         keywords = self.as_keywords(ignore=("axis_forward", "axis_up",
                                             "filter_glob", "split_mode"))
-
         return SceneImporter().set_filename(keywords['filepath']).load(
             context, **keywords)
 
-    def draw(self, context):
-
+    def draw(self,
+             context):
         layout = self.layout
         layout.label(text="- Primary Import Options -")
-
         row = layout.row()
         row.prop(self, "scenes_as_camera")
         row = layout.row()
@@ -901,9 +1067,9 @@ class ImportSKP(Operator, ImportHelper):
         row = layout.row()
         row.prop(self, "reuse_existing_groups")
         col = layout.column()
-        col.label(text="- Instanciate When Similar Objects Are Over -")
-        split = col.split(factor=0.5)
-        col = split.column()
+        col.label(text="- Instantiate components, if they are more than -")
+        #split = col.split(factor=0.5)
+        #col = split.column()
         col.prop(self, "max_instance")
         row = layout.row()
         row.use_property_split = True
@@ -911,42 +1077,38 @@ class ImportSKP(Operator, ImportHelper):
         row = layout.row()
         row.use_property_split = True
         row.prop(self, "import_scene")
-        row = layout.row()
-        row.use_property_split = True
-        row.prop(self, "render_engine")
+        #row = layout.row()
+        #row.use_property_split = True
+        #row.prop(self, "render_engine")
 
 
 class ExportSKP(Operator, ExportHelper):
-    """Load a Trimble Sketchup SKP file"""
-
+    """Export .blend into .skp file"""
     bl_idname = "export_scene.skp"
     bl_label = "Export SKP"
     bl_options = {'PRESET', 'UNDO'}
-
     filename_ext = ".skp"
 
-    def execute(self, context):
-
+    def execute(self,
+                context):
         keywords = self.as_keywords()
+        return SceneExporter().set_filename(keywords['filepath']) \
+            .save(context, **keywords)
 
-        return SceneExporter().set_filename(keywords['filepath']).save(
-            context, **keywords)
 
-
-def menu_func_import(self, context):
-
+def menu_func_import(self,
+                     context):
     self.layout.operator(ImportSKP.bl_idname,
-                         text="Import Sketchup Scene(.skp)")
+                         text="SketchUp (.skp)")
 
 
-def menu_func_export(self, context):
-
+def menu_func_export(self,
+                     context):
     self.layout.operator(ExportSKP.bl_idname,
-                         text="Export Sketchup Scene(.skp)")
+                         text="SketchUp (.skp)")
 
 
 def register():
-
     bpy.utils.register_class(SketchupAddonPreferences)
     bpy.utils.register_class(ImportSKP)
     bpy.types.TOPBAR_MT_file_import.append(menu_func_import)
@@ -955,7 +1117,6 @@ def register():
 
 
 def unregister():
-
     bpy.utils.unregister_class(ImportSKP)
     bpy.types.TOPBAR_MT_file_import.remove(menu_func_import)
     bpy.utils.unregister_class(ExportSKP)


### PR DESCRIPTION
Revised __init__.py so that outliner structure from SketchUp is preserved in Blender. Components are imported as duplicated objects. Some minor issues still exist for models where components or groups have been copied and transformed (combination of rotation, scaling, translation). Workaround is to explode and regroup in SketchUp before importing. Revised importer has been tested on SketchUp files > 300 MB with success.