### PR TITLE
Fix: Use __package__ to get addon prefs for Blender 4.x compatibility

### DIFF
--- a/sketchup_importer/__init__.py
+++ b/sketchup_importer/__init__.py
@@ -165,7 +165,7 @@ class SceneImporter():
             skp_log(f'Importing: {self.filepath}')
 
         addon_name = __name__.split('.')[0]
-        self.prefs = context.preferences.addons[addon_name].preferences
+        self.prefs = context.preferences.addons[__package__].preferences
 
         _time_main = time.time()
 


### PR DESCRIPTION
Hello! This PR fixes a `KeyError` crash that occurs when trying to import a file in Blender 4.2+ due to changes in the new Extensions system.

**The Problem:**
The addon was trying to access its own preferences using methods that are no longer reliable in the context where the operator runs, leading to a `KeyError: 'key not found'` crash.

**The Solution:**
This change replaces the preference access method with `context.preferences.addons[__package__].preferences`. The `__package__` variable reliably provides the addon's own ID without needing to look it up, resolving the issue.

This makes the addon usable again.